### PR TITLE
Set preview buffer as scratch

### DIFF
--- a/autoload/slumlord.vim
+++ b/autoload/slumlord.vim
@@ -223,6 +223,10 @@ function s:WinUpdater.__moveToWin() abort
     else
         let prev_bnum = bufnr("")
         new
+        setlocal buftype=nofile
+        setlocal bufhidden=delete
+        setlocal noswapfile
+        setlocal textwidth=0 " avoid automatic line break
         call setbufvar(prev_bnum, "slumlord_bnum", bufnr(""))
         call self.__setupWinOpts()
     endif

--- a/autoload/slumlord.vim
+++ b/autoload/slumlord.vim
@@ -214,7 +214,7 @@ function! s:WinUpdater.update(args) abort
 endfunction
 
 function s:WinUpdater.__moveToWin() abort
-    if exists("b:slumlord_bnum")
+    if exists("b:slumlord_bnum") && bufexists(b:slumlord_bnum)
         if bufwinnr(b:slumlord_bnum) != -1
             exec bufwinnr(b:slumlord_bnum) . "wincmd w"
         else
@@ -224,7 +224,7 @@ function s:WinUpdater.__moveToWin() abort
         let prev_bnum = bufnr("")
         new
         setlocal buftype=nofile
-        setlocal bufhidden=delete
+        setlocal bufhidden=wipe
         setlocal noswapfile
         setlocal textwidth=0 " avoid automatic line break
         call setbufvar(prev_bnum, "slumlord_bnum", bufnr(""))


### PR DESCRIPTION
Hello,

I've just started using this plugin, and it is great!

While using `g:slumlord_separate_win=1` I noticed that Vim keeps asking "Save changes to ..." about the preview buffer.
The proposed changes avoid this by following the approach on `:h special-buffers`.