### PR TITLE
Use headless Java mode when invoking plantuml jar

### DIFF
--- a/autoload/slumlord.vim
+++ b/autoload/slumlord.vim
@@ -39,7 +39,7 @@ function! slumlord#updatePreview(args) abort
     call s:mungeDiagramInTmpFile(tmpfname)
     let b:slumlord_preview_fname = fnamemodify(tmpfname,  ':r') . '.' . ext
 
-    let cmd = "java -Dapple.awt.UIElement=true -Dplantuml.include.path=\"". g:slumlord_plantuml_include_path ."\" -splash: -jar ". g:slumlord_plantuml_jar_path ." -charset ". charset ." -t" . type ." ". tmpfname
+    let cmd = "java -Dapple.awt.UIElement=true -Djava.awt.headless=true -Dplantuml.include.path=\"". g:slumlord_plantuml_include_path ."\" -splash: -jar ". g:slumlord_plantuml_jar_path ." -charset ". charset ." -t" . type ." ". tmpfname
 
     let write = has_key(a:args, 'write') && a:args["write"] == 1
     if exists("*jobstart")
@@ -243,7 +243,7 @@ function s:WinUpdater.__setupWinOpts() abort
     syn match plantumlPreviewTitleUnderline #\^\+#
     syn match plantumlPreviewNoteText #║[^┌┐└┘┬─│┴<>╚═╪╝╔═╤╪╗║╧╟╠╣]*[░ ]║#hs=s+1,he=e-2
     syn match plantumlPreviewDividerText #╣[^┌┐└┘┬─│┴<>╚═╪╝╔═╤╪╗║╧╟╣]*╠#hs=s+1,he=e-1
-    syn match plantumlPreviewMethodCall #\(\(│\|^\)\s*\)\@<=[a-zA-Z_]*([[:alnum:],_ ]*)# 
+    syn match plantumlPreviewMethodCall #\(\(│\|^\)\s*\)\@<=[a-zA-Z_]*([[:alnum:],_ ]*)#
     syn match plantumlPreviewMethodCallParen #[()]# containedin=plantumlPreviewMethodCall contained
 
     hi def link plantumlPreviewBoxParts normal


### PR DESCRIPTION
Hello, I was trying to resolve an issue where nothing would happen on saving the UML text file on my system (for which there is an issue opened also), which lead me conclusion that headless mode should be used when invoking plantuml jar. 
I'm not very familiar with this project, so I'm hoping to have comment if I missed anything.

Thanks, 
Sava